### PR TITLE
Add PollActivityExecutionOutcome and PollWorkflowUpdateOutcome to Client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -12,6 +12,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/operatorservice/v1"
+	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"io"
 
@@ -1431,6 +1432,32 @@ type (
 		//
 		// NOTE: Experimental
 		CountActivities(ctx context.Context, options CountActivitiesOptions) (*CountActivitiesResult, error)
+
+		// PollActivityExecutionOutcome long-polls for a standalone activity's
+		// outcome, returning the raw gRPC response. Nil-outcome responses and
+		// per-request timeouts are retried internally. The loop terminates when
+		// an outcome is received, the parent context is cancelled, or a
+		// non-timeout gRPC error occurs.
+		//
+		// Unlike ActivityHandle.Get, this method does not convert protos to SDK
+		// types. It is intended for callers that need raw proto payloads and
+		// failure details (e.g. stack traces, source, cause chains).
+		//
+		// NOTE: Experimental
+		PollActivityExecutionOutcome(ctx context.Context, activityID string, runID string) (*workflowservice.PollActivityExecutionResponse, error)
+
+		// PollWorkflowUpdateOutcome long-polls for a workflow update's outcome,
+		// returning the raw gRPC response. Nil-outcome responses and per-request
+		// timeouts are retried internally. The loop terminates when an outcome
+		// is received, the parent context is cancelled, or a non-timeout gRPC
+		// error occurs.
+		//
+		// Unlike WorkflowUpdateHandle.Get, this method does not convert protos
+		// to SDK types. It is intended for callers that need raw proto payloads
+		// and failure details (e.g. stack traces, source, cause chains).
+		//
+		// NOTE: Experimental
+		PollWorkflowUpdateOutcome(ctx context.Context, updateRef *updatepb.UpdateRef) (*workflowservice.PollWorkflowExecutionUpdateResponse, error)
 
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the

--- a/internal/client.go
+++ b/internal/client.go
@@ -11,6 +11,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/operatorservice/v1"
+	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -479,6 +480,18 @@ type (
 		//
 		// NOTE: Experimental
 		CountActivities(ctx context.Context, options ClientCountActivitiesOptions) (*ClientCountActivitiesResult, error)
+
+		// PollActivityExecutionOutcome long-polls for a standalone activity's
+		// outcome, returning the raw gRPC response.
+		//
+		// NOTE: Experimental
+		PollActivityExecutionOutcome(ctx context.Context, activityID string, runID string) (*workflowservice.PollActivityExecutionResponse, error)
+
+		// PollWorkflowUpdateOutcome long-polls for a workflow update's outcome,
+		// returning the raw gRPC response.
+		//
+		// NOTE: Experimental
+		PollWorkflowUpdateOutcome(ctx context.Context, updateRef *updatepb.UpdateRef) (*workflowservice.PollWorkflowExecutionUpdateResponse, error)
 
 		// WorkflowService provides access to the underlying gRPC service. This should only be used for advanced use cases
 		// that cannot be accomplished via other Client methods. Unlike calls to other Client methods, calls directly to the

--- a/internal/internal_activity_client.go
+++ b/internal/internal_activity_client.go
@@ -639,27 +639,70 @@ func (w *workflowClientInterceptor) GetActivityHandle(
 	}
 }
 
+// PollActivityExecutionOutcome long-polls for a standalone activity's outcome,
+// returning the raw gRPC response. It loops internally: nil-outcome responses
+// (the server's long-poll keepalive) and per-request timeouts are retried
+// automatically. The loop terminates when an outcome is received, the parent
+// context is cancelled, or a non-timeout gRPC error occurs.
+//
+// This method does not go through the interceptor chain and does not convert
+// protos to SDK types. It is intended for callers (such as the CLI) that need
+// access to raw proto payloads and failure details.
+//
+// NOTE: Experimental
+func (wc *WorkflowClient) PollActivityExecutionOutcome(
+	ctx context.Context,
+	activityID string,
+	runID string,
+) (*workflowservice.PollActivityExecutionResponse, error) {
+	if err := wc.ensureInitialized(ctx); err != nil {
+		return nil, err
+	}
+	return wc.pollActivityExecutionOutcome(ctx, activityID, runID)
+}
+
+func (wc *WorkflowClient) pollActivityExecutionOutcome(
+	ctx context.Context,
+	activityID string,
+	runID string,
+) (*workflowservice.PollActivityExecutionResponse, error) {
+	request := &workflowservice.PollActivityExecutionRequest{
+		Namespace:  wc.namespace,
+		ActivityId: activityID,
+		RunId:      runID,
+	}
+	for {
+		grpcCtx, cancel := newGRPCContext(ctx,
+			grpcLongPoll(true),
+			grpcTimeout(pollActivityTimeout),
+			defaultGrpcRetryParameters(ctx),
+		)
+		resp, err := wc.WorkflowService().PollActivityExecution(grpcCtx, request)
+		pollTimedOut := grpcCtx.Err() != nil
+		cancel()
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			if pollTimedOut {
+				continue
+			}
+			return nil, err
+		}
+		if resp.GetOutcome() != nil {
+			return resp, nil
+		}
+	}
+}
+
 func (w *workflowClientInterceptor) PollActivityResult(
 	ctx context.Context,
 	in *ClientPollActivityResultInput,
 ) (*ClientPollActivityResultOutput, error) {
-	request := &workflowservice.PollActivityExecutionRequest{
-		Namespace:  w.client.namespace,
-		ActivityId: in.ActivityID,
-		RunId:      in.RunID,
+	resp, err := w.client.pollActivityExecutionOutcome(ctx, in.ActivityID, in.RunID)
+	if err != nil {
+		return nil, err
 	}
-
-	var resp *workflowservice.PollActivityExecutionResponse
-	for resp.GetOutcome() == nil {
-		grpcCtx, cancel := newGRPCContext(ctx, grpcLongPoll(true), grpcTimeout(pollActivityTimeout), defaultGrpcRetryParameters(ctx))
-		var err error
-		resp, err = w.client.WorkflowService().PollActivityExecution(grpcCtx, request)
-		cancel()
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	switch v := resp.GetOutcome().GetValue().(type) {
 	case *activitypb.ActivityExecutionOutcome_Result:
 		return &ClientPollActivityResultOutput{Result: newEncodedValue(v.Result, w.client.dataConverter)}, nil

--- a/internal/internal_workflow_client.go
+++ b/internal/internal_workflow_client.go
@@ -2543,58 +2543,91 @@ func (w *workflowClientInterceptor) createUpdateWorkflowRequest(
 	}, nil
 }
 
-func (w *workflowClientInterceptor) PollWorkflowUpdate(
-	parentCtx context.Context,
-	in *ClientPollWorkflowUpdateInput,
-) (*ClientPollWorkflowUpdateOutput, error) {
-	// header, _ = headerPropagated(ctx, w.client.contextPropagators)
-	// todo header not in PollWorkflowUpdate
+// PollWorkflowUpdateOutcome long-polls for a workflow update's outcome,
+// returning the raw gRPC response. It loops internally: nil-outcome responses
+// (the server's long-poll keepalive) and per-request timeouts are retried
+// automatically. The loop terminates when an outcome is received, the parent
+// context is cancelled, or a non-timeout gRPC error occurs.
+//
+// This method does not go through the interceptor chain and does not convert
+// protos to SDK types. It is intended for callers (such as the CLI) that need
+// access to raw proto payloads and failure details.
+//
+// NOTE: Experimental
+func (wc *WorkflowClient) PollWorkflowUpdateOutcome(
+	ctx context.Context,
+	updateRef *updatepb.UpdateRef,
+) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
+	if err := wc.ensureInitialized(ctx); err != nil {
+		return nil, err
+	}
+	return wc.pollWorkflowUpdateOutcome(ctx, updateRef)
+}
 
+func (wc *WorkflowClient) pollWorkflowUpdateOutcome(
+	ctx context.Context,
+	updateRef *updatepb.UpdateRef,
+) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
 	pollReq := workflowservice.PollWorkflowExecutionUpdateRequest{
-		Namespace: w.client.namespace,
-		UpdateRef: in.UpdateRef,
-		Identity:  w.client.identity,
+		Namespace: wc.namespace,
+		UpdateRef: updateRef,
+		Identity:  wc.identity,
 		WaitPolicy: &updatepb.WaitPolicy{
 			LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
 		},
 	}
 	for {
-		ctx, cancel := newGRPCContext(
-			parentCtx,
+		grpcCtx, cancel := newGRPCContext(ctx,
 			grpcLongPoll(true),
 			grpcTimeout(pollUpdateTimeout),
 		)
-		ctx = context.WithValue(
-			ctx,
+		grpcCtx = context.WithValue(grpcCtx,
 			retry.ConfigKey,
-			createDynamicServiceRetryPolicy(ctx).GrpcRetryConfig(),
+			createDynamicServiceRetryPolicy(grpcCtx).GrpcRetryConfig(),
 		)
-		resp, err := w.client.workflowService.PollWorkflowExecutionUpdate(ctx, &pollReq)
+		resp, err := wc.workflowService.PollWorkflowExecutionUpdate(grpcCtx, &pollReq)
+		pollTimedOut := grpcCtx.Err() != nil
 		cancel()
-		if err == nil && resp.GetOutcome() == nil {
-			continue
-		}
 		if err != nil {
 			if ctx.Err() != nil {
-				return nil, NewWorkflowUpdateServiceTimeoutOrCanceledError(err)
+				return nil, ctx.Err()
 			}
-			if code := status.Code(err); code == codes.Canceled || code == codes.DeadlineExceeded {
-				return nil, NewWorkflowUpdateServiceTimeoutOrCanceledError(err)
+			if pollTimedOut {
+				continue
 			}
 			return nil, err
 		}
-		switch v := resp.GetOutcome().GetValue().(type) {
-		case *updatepb.Outcome_Failure:
-			return &ClientPollWorkflowUpdateOutput{
-				Error: w.client.failureConverter.FailureToError(v.Failure),
-			}, nil
-		case *updatepb.Outcome_Success:
-			return &ClientPollWorkflowUpdateOutput{
-				Result: newEncodedValue(v.Success, w.client.dataConverter),
-			}, nil
-		default:
-			return nil, fmt.Errorf("unsupported outcome type %T", v)
+		if resp.GetOutcome() != nil {
+			return resp, nil
 		}
+	}
+}
+
+func (w *workflowClientInterceptor) PollWorkflowUpdate(
+	parentCtx context.Context,
+	in *ClientPollWorkflowUpdateInput,
+) (*ClientPollWorkflowUpdateOutput, error) {
+	resp, err := w.client.pollWorkflowUpdateOutcome(parentCtx, in.UpdateRef)
+	if err != nil {
+		if parentCtx.Err() != nil {
+			return nil, NewWorkflowUpdateServiceTimeoutOrCanceledError(err)
+		}
+		if code := status.Code(err); code == codes.Canceled || code == codes.DeadlineExceeded {
+			return nil, NewWorkflowUpdateServiceTimeoutOrCanceledError(err)
+		}
+		return nil, err
+	}
+	switch v := resp.GetOutcome().GetValue().(type) {
+	case *updatepb.Outcome_Failure:
+		return &ClientPollWorkflowUpdateOutput{
+			Error: w.client.failureConverter.FailureToError(v.Failure),
+		}, nil
+	case *updatepb.Outcome_Success:
+		return &ClientPollWorkflowUpdateOutput{
+			Result: newEncodedValue(v.Success, w.client.dataConverter),
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported outcome type %T", v)
 	}
 }
 

--- a/internal/internal_workflow_client_test.go
+++ b/internal/internal_workflow_client_test.go
@@ -20,8 +20,10 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	activitypb "go.temporal.io/api/activity/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
@@ -2648,5 +2650,186 @@ func TestUpdate(t *testing.T) {
 		// Verify that calling Get with nil does not panic
 		err = handle.Get(context.TODO(), nil)
 		require.NoError(t, err)
+	})
+}
+
+func TestPollWorkflowUpdateOutcome(t *testing.T) {
+	dc := converter.GetDefaultDataConverter()
+
+	init := func(t *testing.T) (*workflowservicemock.MockWorkflowServiceClient, *WorkflowClient) {
+		svc := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
+		client := NewServiceClient(svc, nil, ClientOptions{})
+		svc.EXPECT().
+			GetSystemInfo(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&workflowservice.GetSystemInfoResponse{}, nil)
+		return svc, client
+	}
+
+	ref := &updatepb.UpdateRef{
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: "wf-id",
+			RunId:      "run-id",
+		},
+		UpdateId: "update-id",
+	}
+
+	t.Run("success", func(t *testing.T) {
+		svc, client := init(t)
+		payload, _ := dc.ToPayloads("result-value")
+		svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
+			Return(&workflowservice.PollWorkflowExecutionUpdateResponse{
+				Outcome: &updatepb.Outcome{
+					Value: &updatepb.Outcome_Success{Success: payload},
+				},
+				Stage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+			}, nil)
+		resp, err := client.PollWorkflowUpdateOutcome(context.TODO(), ref)
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetOutcome().GetValue().(*updatepb.Outcome_Success))
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		svc, client := init(t)
+		svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
+			Return(&workflowservice.PollWorkflowExecutionUpdateResponse{
+				Outcome: &updatepb.Outcome{
+					Value: &updatepb.Outcome_Failure{
+						Failure: &failurepb.Failure{Message: "update failed"},
+					},
+				},
+			}, nil)
+		resp, err := client.PollWorkflowUpdateOutcome(context.TODO(), ref)
+		require.NoError(t, err)
+		f := resp.GetOutcome().GetValue().(*updatepb.Outcome_Failure)
+		require.Equal(t, "update failed", f.Failure.GetMessage())
+	})
+
+	t.Run("retries on nil outcome", func(t *testing.T) {
+		svc, client := init(t)
+		payload, _ := dc.ToPayloads("delayed-result")
+		gomock.InOrder(
+			svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
+				Return(&workflowservice.PollWorkflowExecutionUpdateResponse{Outcome: nil}, nil),
+			svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
+				Return(&workflowservice.PollWorkflowExecutionUpdateResponse{
+					Outcome: &updatepb.Outcome{
+						Value: &updatepb.Outcome_Success{Success: payload},
+					},
+				}, nil),
+		)
+		resp, err := client.PollWorkflowUpdateOutcome(context.TODO(), ref)
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetOutcome())
+	})
+
+	t.Run("parent context cancelled", func(t *testing.T) {
+		svc, client := init(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ *workflowservice.PollWorkflowExecutionUpdateRequest, _ ...grpc.CallOption) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
+				cancel()
+				return nil, ctx.Err()
+			})
+		_, err := client.PollWorkflowUpdateOutcome(ctx, ref)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("gRPC error propagated", func(t *testing.T) {
+		svc, client := init(t)
+		svc.EXPECT().PollWorkflowExecutionUpdate(gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("server error"))
+		_, err := client.PollWorkflowUpdateOutcome(context.TODO(), ref)
+		require.ErrorContains(t, err, "server error")
+	})
+}
+
+func TestPollActivityExecutionOutcome(t *testing.T) {
+	init := func(t *testing.T) (*workflowservicemock.MockWorkflowServiceClient, *WorkflowClient) {
+		svc := workflowservicemock.NewMockWorkflowServiceClient(gomock.NewController(t))
+		client := NewServiceClient(svc, nil, ClientOptions{})
+		svc.EXPECT().
+			GetSystemInfo(gomock.Any(), gomock.Any()).
+			AnyTimes().
+			Return(&workflowservice.GetSystemInfoResponse{}, nil)
+		return svc, client
+	}
+
+	t.Run("success", func(t *testing.T) {
+		svc, client := init(t)
+		dc := converter.GetDefaultDataConverter()
+		payload, _ := dc.ToPayloads("activity-result")
+		svc.EXPECT().PollActivityExecution(gomock.Any(), gomock.Any()).
+			Return(&workflowservice.PollActivityExecutionResponse{
+				RunId: "run-1",
+				Outcome: &activitypb.ActivityExecutionOutcome{
+					Value: &activitypb.ActivityExecutionOutcome_Result{Result: payload},
+				},
+			}, nil)
+		resp, err := client.PollActivityExecutionOutcome(context.TODO(), "act-1", "run-1")
+		require.NoError(t, err)
+		require.Equal(t, "run-1", resp.GetRunId())
+		require.NotNil(t, resp.GetOutcome().GetValue().(*activitypb.ActivityExecutionOutcome_Result))
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		svc, client := init(t)
+		svc.EXPECT().PollActivityExecution(gomock.Any(), gomock.Any()).
+			Return(&workflowservice.PollActivityExecutionResponse{
+				Outcome: &activitypb.ActivityExecutionOutcome{
+					Value: &activitypb.ActivityExecutionOutcome_Failure{
+						Failure: &failurepb.Failure{
+							Message:    "activity failed",
+							StackTrace: "goroutine 1 ...",
+							Source:     "GoSDK",
+						},
+					},
+				},
+			}, nil)
+		resp, err := client.PollActivityExecutionOutcome(context.TODO(), "act-1", "")
+		require.NoError(t, err)
+		f := resp.GetOutcome().GetValue().(*activitypb.ActivityExecutionOutcome_Failure)
+		require.Equal(t, "activity failed", f.Failure.GetMessage())
+		require.Equal(t, "goroutine 1 ...", f.Failure.GetStackTrace())
+		require.Equal(t, "GoSDK", f.Failure.GetSource())
+	})
+
+	t.Run("retries on nil outcome", func(t *testing.T) {
+		svc, client := init(t)
+		dc := converter.GetDefaultDataConverter()
+		payload, _ := dc.ToPayloads("delayed")
+		gomock.InOrder(
+			svc.EXPECT().PollActivityExecution(gomock.Any(), gomock.Any()).
+				Return(&workflowservice.PollActivityExecutionResponse{Outcome: nil}, nil),
+			svc.EXPECT().PollActivityExecution(gomock.Any(), gomock.Any()).
+				Return(&workflowservice.PollActivityExecutionResponse{
+					Outcome: &activitypb.ActivityExecutionOutcome{
+						Value: &activitypb.ActivityExecutionOutcome_Result{Result: payload},
+					},
+				}, nil),
+		)
+		resp, err := client.PollActivityExecutionOutcome(context.TODO(), "act-1", "")
+		require.NoError(t, err)
+		require.NotNil(t, resp.GetOutcome())
+	})
+
+	t.Run("parent context cancelled", func(t *testing.T) {
+		svc, client := init(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		svc.EXPECT().PollActivityExecution(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ *workflowservice.PollActivityExecutionRequest, _ ...grpc.CallOption) (*workflowservice.PollActivityExecutionResponse, error) {
+				cancel()
+				return nil, ctx.Err()
+			})
+		_, err := client.PollActivityExecutionOutcome(ctx, "act-1", "")
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("gRPC error propagated", func(t *testing.T) {
+		svc, client := init(t)
+		svc.EXPECT().PollActivityExecution(gomock.Any(), gomock.Any()).
+			Return(nil, fmt.Errorf("not found"))
+		_, err := client.PollActivityExecutionOutcome(context.TODO(), "act-1", "")
+		require.ErrorContains(t, err, "not found")
 	})
 }

--- a/internal/nexus_operations.go
+++ b/internal/nexus_operations.go
@@ -12,6 +12,7 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	nexuspb "go.temporal.io/api/nexus/v1"
 	"go.temporal.io/api/operatorservice/v1"
+	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -720,6 +721,14 @@ func (t *testSuiteClientForNexusOperations) ListActivities(ctx context.Context, 
 }
 
 func (t *testSuiteClientForNexusOperations) CountActivities(ctx context.Context, options ClientCountActivitiesOptions) (*ClientCountActivitiesResult, error) {
+	panic("unimplemented in the test environment")
+}
+
+func (t *testSuiteClientForNexusOperations) PollActivityExecutionOutcome(ctx context.Context, activityID string, runID string) (*workflowservice.PollActivityExecutionResponse, error) {
+	panic("unimplemented in the test environment")
+}
+
+func (t *testSuiteClientForNexusOperations) PollWorkflowUpdateOutcome(ctx context.Context, updateRef *updatepb.UpdateRef) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
 	panic("unimplemented in the test environment")
 }
 

--- a/mocks/Client.go
+++ b/mocks/Client.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"go.temporal.io/api/operatorservice/v1"
-
+	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 )
 
@@ -1197,6 +1197,64 @@ func (_m *Client) CountActivities(ctx context.Context, options client.CountActiv
 
 	if rf, ok := ret.Get(1).(func(context.Context, client.CountActivitiesOptions) error); ok {
 		r1 = rf(ctx, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func (_m *Client) PollActivityExecutionOutcome(ctx context.Context, activityID string, runID string) (*workflowservice.PollActivityExecutionResponse, error) {
+	ret := _m.Called(ctx, activityID, runID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PollActivityExecutionOutcome")
+	}
+
+	var r0 *workflowservice.PollActivityExecutionResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (*workflowservice.PollActivityExecutionResponse, error)); ok {
+		return rf(ctx, activityID, runID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) *workflowservice.PollActivityExecutionResponse); ok {
+		r0 = rf(ctx, activityID, runID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*workflowservice.PollActivityExecutionResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, activityID, runID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func (_m *Client) PollWorkflowUpdateOutcome(ctx context.Context, updateRef *updatepb.UpdateRef) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
+	ret := _m.Called(ctx, updateRef)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PollWorkflowUpdateOutcome")
+	}
+
+	var r0 *workflowservice.PollWorkflowExecutionUpdateResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *updatepb.UpdateRef) (*workflowservice.PollWorkflowExecutionUpdateResponse, error)); ok {
+		return rf(ctx, updateRef)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *updatepb.UpdateRef) *workflowservice.PollWorkflowExecutionUpdateResponse); ok {
+		r0 = rf(ctx, updateRef)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*workflowservice.PollWorkflowExecutionUpdateResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *updatepb.UpdateRef) error); ok {
+		r1 = rf(ctx, updateRef)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -8679,7 +8679,8 @@ func (ts *IntegrationTestSuite) TestExecuteActivitySuite() {
 	var activities Activities
 
 	activityResultChan := make(chan string)
-	readFromChannelActivity := func() (string, error) {
+	readFromChannelActivity := func(delay time.Duration) (string, error) {
+		time.Sleep(delay)
 		return <-activityResultChan, nil
 	}
 	ts.worker.RegisterActivityWithOptions(readFromChannelActivity, activity.RegisterOptions{Name: "readFromChannelActivity"})
@@ -8695,7 +8696,7 @@ func (ts *IntegrationTestSuite) TestExecuteActivitySuite() {
 
 		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 		defer cancel()
-		handle, err := ts.client.ExecuteActivity(ctx, options, "readFromChannelActivity")
+		handle, err := ts.client.ExecuteActivity(ctx, options, "readFromChannelActivity", 100*time.Millisecond)
 		ts.NoError(err)
 		ts.Equal(options.ID, handle.GetID())
 		ts.NotEmpty(handle.GetRunID())
@@ -8721,8 +8722,6 @@ func (ts *IntegrationTestSuite) TestExecuteActivitySuite() {
 		ts.NoError(err)
 		ts.Equal(options.Details, details)
 
-		// ensure measurable amount of time passes, then complete activity
-		time.Sleep(100 * time.Millisecond)
 		activityResultChan <- ""
 		err = handle.Get(ctx, nil)
 		ts.NoError(err)
@@ -8742,7 +8741,7 @@ func (ts *IntegrationTestSuite) TestExecuteActivitySuite() {
 	ts.Run("Wait for activity result", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 		defer cancel()
-		handle, err := ts.client.ExecuteActivity(ctx, makeOptions(), "readFromChannelActivity")
+		handle, err := ts.client.ExecuteActivity(ctx, makeOptions(), "readFromChannelActivity", time.Duration(0))
 		ts.NoError(err)
 
 		receivedResultChan := make(chan string)
@@ -8905,7 +8904,7 @@ func (ts *IntegrationTestSuite) TestExecuteActivitySuite() {
 	ts.Run("Activity result timeout", func() {
 		ctx, cancel := context.WithTimeout(context.Background(), ctxTimeout)
 		defer cancel()
-		handle, err := ts.client.ExecuteActivity(ctx, makeOptions(), "readFromChannelActivity")
+		handle, err := ts.client.ExecuteActivity(ctx, makeOptions(), "readFromChannelActivity", time.Duration(0))
 		ts.NoError(err)
 
 		getCtx, getCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
@@ -8914,5 +8913,24 @@ func (ts *IntegrationTestSuite) TestExecuteActivitySuite() {
 		var serviceErr *serviceerror.DeadlineExceeded
 		ts.True(errors.Is(err, context.DeadlineExceeded) || errors.As(err, &serviceErr))
 		activityResultChan <- "" // allow activity to complete
+	})
+
+	// Verifies that handle.Get() can wait longer than the internal gRPC
+	// per-RPC timeout (defaultRPCTimeout = 10s).
+	ts.Run("Polling does not cease prematurely", func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+
+		options := makeOptions()
+		options.ScheduleToCloseTimeout = 60 * time.Second
+		handle, err := ts.client.ExecuteActivity(ctx, options, "readFromChannelActivity", 15*time.Second)
+		ts.NoError(err)
+
+		go func() { activityResultChan <- "done" }()
+
+		var result string
+		err = handle.Get(ctx, &result)
+		ts.NoError(err, "handle.Get() should survive beyond the 10s internal gRPC timeout")
+		ts.Equal("done", result)
 	})
 }


### PR DESCRIPTION
These new methods perform the long-poll loop and return raw gRPC proto responses, without converting to SDK types. They are intended for callers (such as the CLI) that need access to raw proto payloads and failure details (stack traces, source, cause chains).

The existing interceptor methods (PollActivityResult, PollWorkflowUpdate) are refactored to call the new internal helpers, preserving their current behavior. The raw methods also improve per-request timeout handling: they retry internally when a per-request timeout fires but the parent context is still alive, rather than surfacing it as an error.